### PR TITLE
remove keydown event location check

### DIFF
--- a/showdragdistance.js
+++ b/showdragdistance.js
@@ -577,7 +577,7 @@ Hooks.on('ready',()=>{
 		switch(e.which){
 			case 17:
 				ctrlPressed = true;
-				if(canvas.controls.dragRuler.active == false && e.originalEvent.location == 1 && !rangeFinder && canvas.tokens.controlled.length>0 && game.settings.get('ShowDragDistance','rangeFinder') === true && canvas.mouseInteractionManager.state !=0 && game.activeTool !='ruler'){
+				if(canvas.controls.dragRuler.active == false && !rangeFinder && canvas.tokens.controlled.length>0 && game.settings.get('ShowDragDistance','rangeFinder') === true && canvas.mouseInteractionManager.state !=0 && game.activeTool !='ruler'){
 					rangeFinder = true;
 					canvas.controls.ruler._state = Ruler.STATES.MEASURING;
 					canvas.controls.ruler._addWaypoint(canvas.tokens.controlled[0].center)


### PR DESCRIPTION
I have my ctrl key remapped to my caps lock key on my mac and noticed that I could no longer get the rangefinder to appear. This is due to the fact that MacOS remaps the key with a location of 2 instead of 1 (which is what the module is looking for). I removed that restriction and now am able to get rangefinder to appear with my remapped control key.

If there was a reason for the limitation on the event location, I can try and find another workaround. Thanks for making this plugin :) 

![key remapping](https://user-images.githubusercontent.com/18057119/105796224-63bea300-5f5c-11eb-96e0-3e6c420371f4.png)
