### PR TITLE
Fix _handleDragCancel bug

### DIFF
--- a/showdragdistance.js
+++ b/showdragdistance.js
@@ -531,7 +531,7 @@ class DragRuler extends Ruler{
 		let handleDragCancel = MouseInteractionManager.prototype._handleDragCancel;
 		MouseInteractionManager.prototype._handleDragCancel = function(event){
 			
-			if((typeof this.object.data != 'undefined') && typeof this.object.data.flags['pick-up-stix'] == 'undefined'){
+			if(ui.controls.activeControl === 'token' && typeof this.object.data != 'undefined' && typeof this.object.data.flags['pick-up-stix'] == 'undefined'){
 				if( canvas.tokens.controlled.length > 0 && canvas.tokens.controlled[0].mouseInteractionManager.state == 3 ){
 					switch(event.button){
 						case 0:


### PR DESCRIPTION
Just a one line change to play better with other modules. AFAIK ShowDragDistance only needs to work on the token layer. It was causing conflicts with my module [Blood n Guts](https://github.com/edzillion/blood-n-guts) which uses the same workflow, so I just added a check on `MouseInteractionManager.prototype._handleDragCancel = function(event){` to make sure we are on the token layer.

